### PR TITLE
add shop link (no url hold off on merge for now)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -43,7 +43,7 @@
             <li @click="showNav = !showNav"><router-link to="/events" class="d-flex"><i></i> <span>EVENTS</span></router-link></li>
             <li @click="showNav = !showNav"><a href="https://www.patreon.com/blackartistdatabase" target="_blank" class="d-flex"><i></i> <span>PATREON</span></a></li>
             <li @click="showNav = !showNav">
-              <a href="" target="_blank" class="d-flex"><i></i>STORE</a>
+              <a href="https://www.store.blackartistdatabase.co" target="_blank" class="d-flex"><i></i>STORE</a>
             </li>
           </ul>
         </nav>


### PR DESCRIPTION
To be added as well in the wordpress after the patreon link

```
<li @click="showNav = !showNav">
     <a href="" target="_blank" class="d-flex"><i></i>STORE</a>
</li>
```

